### PR TITLE
Increases the character slots.

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//doohickeys for savefiles
 	var/path
 	var/default_slot = 1 //Holder so it doesn't default to slot 1, rather the last one used
-	var/max_save_slots = 3
+	var/max_save_slots = 10
 
 	//non-preference stuff
 	var/muted = 0
@@ -101,7 +101,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				try_savefile_type_migration()
 			unlock_content = !!parent.IsByondMember()
 			if(unlock_content)
-				max_save_slots = 8
+				max_save_slots = 20
 	else
 		CRASH("attempted to create a preferences datum without a client or mock!")
 	load_savefile()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
@@ -96,12 +96,6 @@ export const CharacterPreferenceWindow = (props, context) => {
             />
           </Stack.Item>
 
-          {!data.content_unlocked && (
-            <Stack.Item align="center">
-              Buy BYOND premium for more slots!
-            </Stack.Item>
-          )}
-
           <Stack.Divider />
 
           <Stack.Item>


### PR DESCRIPTION

## About The Pull Request

This increases the amount of character slots from 3 to 10, and the premium character slots from 8 to 20, like how it was on the old codebase.

This also gets rid of the nag message on the character preferences screen telling you to buy BYOND Premium for more character slots.

## Why It's Good For The Game
## Changelog
:cl:
add: The number of normal character slots has increased from 3 to 10, and the number of premium character slots has increased from 8 to 20.
/:cl:
