### PR TITLE
Adds in an actions-based auto labeler.

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,34 @@
+version: v1
+
+# File-based labels.
+
+labels:
+  - label: "Code"
+    sync: true
+    matcher:
+      files: "code/**"
+
+  - label: "Sprites"
+    sync: true
+    matcher:
+      files: "icons/**"
+
+  - label: "Sound"
+    sync: true
+    matcher:
+      files: "sounds/**"
+  
+  - label: "Maps"
+    sync: true
+    matcher:
+      files: "_maps/**"
+      
+# Body-based labels.
+
+  - label: "Fix"
+    matcher:
+      body: "fix:"
+  
+  - label: "Feature"
+    matcher:
+      body: "add:"

--- a/.github/workflows/auto_labeler.yml
+++ b/.github/workflows/auto_labeler.yml
@@ -1,0 +1,15 @@
+name: Auto Labeler
+
+on:
+  - pull_request_target
+
+jobs:
+  uses:
+    name: labeler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: fuxingloh/multi-labeler@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          config-path: '.github/labels.yml'


### PR DESCRIPTION

## About The Pull Request

This adds in a Github Actions based auto labeler, completely eliminating any need to use the webhooks.

I finally managed to find an auto labeler that could label based on both file changes and the PR body, which allowed me to do this.

## Why It's Good For The Game
## Changelog
No player facing changes.
