### PR TITLE
Makes digitigrade legs ashwalker exclusive.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -13,7 +13,7 @@
 		TRAIT_TACKLING_TAILED_DEFENDER,
 	)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_REPTILE
-	mutant_bodyparts = list("body_markings" = "None", "legs" = "Normal Legs")
+	mutant_bodyparts = list("body_markings" = "None")
 	external_organs = list(
 		/obj/item/organ/external/horns = "None",
 		/obj/item/organ/external/frills = "None",
@@ -36,7 +36,6 @@
 	death_sound = 'sound/voice/lizard/deathsound.ogg'
 	wing_types = list(/obj/item/organ/external/wings/functional/dragon)
 	species_language_holder = /datum/language_holder/lizard
-	digitigrade_customization = DIGITIGRADE_OPTIONAL
 
 	// Lizards are coldblooded and can stand a greater temperature range than humans
 	bodytemp_heat_damage_limit = (BODYTEMP_HEAT_DAMAGE_LIMIT + 20) // This puts lizards 10 above lavaland max heat for ash lizards.

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -136,6 +136,7 @@ Lizard subspecies: ASHWALKERS
 		//TRAIT_LITERATE,
 		TRAIT_VIRUSIMMUNE,
 	)
+	mutant_bodyparts = list("body_markings" = "None", "legs" = "Normal Legs")
 	species_language_holder = /datum/language_holder/lizard/ash
 	digitigrade_customization = DIGITIGRADE_FORCED
 	examine_limb_id = SPECIES_LIZARD

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -136,7 +136,6 @@ Lizard subspecies: ASHWALKERS
 		//TRAIT_LITERATE,
 		TRAIT_VIRUSIMMUNE,
 	)
-	mutant_bodyparts = list("body_markings" = "None", "legs" = "Normal Legs")
 	species_language_holder = /datum/language_holder/lizard/ash
 	digitigrade_customization = DIGITIGRADE_FORCED
 	examine_limb_id = SPECIES_LIZARD

--- a/code/modules/unit_tests/species_change_clothing.dm
+++ b/code/modules/unit_tests/species_change_clothing.dm
@@ -11,7 +11,7 @@
 
 	var/obj/item/human_shoes = morphing_human.get_item_by_slot(ITEM_SLOT_FEET)
 	human_shoes.supports_variations_flags = NONE //do not fit lizards at all costs.
-	morphing_human.set_species(/datum/species/lizard)
+	morphing_human.set_species(/datum/species/lizard/ashwalker)
 	var/obj/item/lizard_shoes = morphing_human.get_item_by_slot(ITEM_SLOT_FEET)
 
 	TEST_ASSERT_NOTEQUAL(human_shoes, lizard_shoes, "Lizard still has shoes after changing species.")


### PR DESCRIPTION
## About The Pull Request

This is a port of https://github.com/sergeirocks100/GearStation/pull/17

Original description:

Nobody is going to read this stuff, but i may as well put it out there anyways.

This, as the title states, removes digitigrade legs as a selectable option from regular lizardpeople. Ashwalkers, however, still have them.

I'm doing this for three reasons:

1. I don't like how they look.
2. I'm not willing to try and accommodate jumpsuits and shoes to them.
3. I can't come up with a good lore reason as to why some lizardpeople have them, and others don't.

I chose to keep them in for ashwalkers, because it makes for a good species downside, and, since they're a separate species of lizard, they actually have a plausible reason to have them lore wise.  

## Why It's Good For The Game
## Changelog
:cl:
add: Lizardpeople can no longer have digitigrade legs. Ashwalkers, however, still have them.
/:cl:
